### PR TITLE
theme from home

### DIFF
--- a/app/src/main/java/com/karrar/movieapp/ui/components/Switch.kt
+++ b/app/src/main/java/com/karrar/movieapp/ui/components/Switch.kt
@@ -17,7 +17,18 @@ class CustomSwitch @JvmOverloads constructor(
     private val binding =
         SwitchToggleBinding.inflate(LayoutInflater.from(context), this)
 
-    private var isOn = false
+    val prefs = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
+    val themeMode = prefs.getString("theme_mode", null)
+
+    private var isOn =  when (themeMode) {
+        "dark" -> true
+        "light" -> false
+        else -> {
+            resources.configuration.uiMode and
+                    android.content.res.Configuration.UI_MODE_NIGHT_MASK ==
+                    android.content.res.Configuration.UI_MODE_NIGHT_YES
+        }
+    }
     private var listener: ((Boolean) -> Unit)? = null
 
     init {

--- a/app/src/main/java/com/karrar/movieapp/ui/components/Switch.kt
+++ b/app/src/main/java/com/karrar/movieapp/ui/components/Switch.kt
@@ -1,0 +1,57 @@
+package com.karrar.movieapp.ui.components
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.FrameLayout
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.karrar.movieapp.databinding.SwitchToggleBinding
+
+
+class CustomSwitch @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0
+) : ConstraintLayout(context, attrs, defStyle) {
+
+    private val binding =
+        SwitchToggleBinding.inflate(LayoutInflater.from(context), this)
+
+    private var isOn = false
+    private var listener: ((Boolean) -> Unit)? = null
+
+    init {
+        updateUI()
+
+        binding.switchContainer.setOnClickListener {
+            toggle()
+        }
+    }
+
+    private fun updateUI() {
+        if (isOn) {
+            binding.switchEnabledOn.visibility = VISIBLE
+            binding.switchEnabledOff.visibility = GONE
+        } else {
+            binding.switchEnabledOn.visibility = GONE
+            binding.switchEnabledOff.visibility = VISIBLE
+        }
+    }
+
+    fun toggle() {
+        isOn = !isOn
+        updateUI()
+        listener?.invoke(isOn)
+    }
+
+    fun setChecked(value: Boolean) {
+        isOn = value
+        updateUI()
+    }
+
+    fun isChecked(): Boolean = isOn
+
+    fun setOnCheckedChangeListener(block: (Boolean) -> Unit) {
+        listener = block
+    }
+}

--- a/app/src/main/java/com/karrar/movieapp/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/karrar/movieapp/ui/main/MainActivity.kt
@@ -6,6 +6,7 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.isVisible
@@ -52,6 +53,18 @@ class MainActivity : AppCompatActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         initializeCustomNavigation()
+
+        val prefs = getSharedPreferences("app_prefs", MODE_PRIVATE)
+        val themeMode = prefs.getString("theme_mode", null)
+
+        if (themeMode != null) {
+            when (themeMode) {
+                "light" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+                "dark" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+            }
+        } else {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/karrar/movieapp/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/karrar/movieapp/ui/profile/ProfileFragment.kt
@@ -1,12 +1,15 @@
 package com.karrar.movieapp.ui.profile
 
+import android.content.Context
 import android.os.Bundle
 import android.view.View
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.karrar.movieapp.R
 import com.karrar.movieapp.databinding.FragmentProfileBinding
 import com.karrar.movieapp.ui.base.BaseFragment
+import com.karrar.movieapp.ui.components.CustomSwitch
 import com.karrar.movieapp.utilities.Constants
 import com.karrar.movieapp.utilities.collectLast
 import dagger.hilt.android.AndroidEntryPoint
@@ -19,6 +22,36 @@ class ProfileFragment : BaseFragment<FragmentProfileBinding>() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setTitle(false)
+        collectLast(viewModel.profileUIEvent) {
+            it.getContentIfNotHandled()?.let { onEvent(it) }
+        }
+
+        val darkModeSwitch = binding.darkModeSwitch
+
+        val prefs = requireContext().getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
+
+        val themeMode = prefs.getString("theme_mode", null)
+        val isDark = when (themeMode) {
+            "dark" -> true
+            "light" -> false
+            else -> {
+                resources.configuration.uiMode and
+                        android.content.res.Configuration.UI_MODE_NIGHT_MASK ==
+                        android.content.res.Configuration.UI_MODE_NIGHT_YES
+            }
+        }
+        darkModeSwitch.setChecked(isDark)
+
+        darkModeSwitch.setOnCheckedChangeListener { isOn ->
+            if (isOn) {
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+                prefs.edit().putString("theme_mode", "dark").apply()
+            } else {
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+                prefs.edit().putString("theme_mode", "light").apply()
+            }
+        }
+
         collectLast(viewModel.profileUIEvent) {
             it.getContentIfNotHandled()?.let { onEvent(it) }
         }

--- a/app/src/main/res/drawable/switch_thumb_gray.xml
+++ b/app/src/main/res/drawable/switch_thumb_gray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
-    <solid android:color="@color/shade_tertiary" />
+    <solid android:color="@color/shade_secondary" />
 </shape>

--- a/app/src/main/res/drawable/switch_thumb_white.xml
+++ b/app/src/main/res/drawable/switch_thumb_white.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
-    <solid android:color="@color/white_primary" />
+    <solid android:color="@color/background_card" />
 </shape>

--- a/app/src/main/res/drawable/switch_track_off.xml
+++ b/app/src/main/res/drawable/switch_track_off.xml
@@ -2,5 +2,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="12dp" />
-    <stroke android:width="1dp" android:color="@color/shade_tertiary" />
+    <solid android:color="@color/background_card" />
+    <stroke android:width="1dp" android:color="@color/shade_secondary" />
 </shape>

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -294,6 +294,16 @@
                             android:layout_marginStart="8dp"
                             />
 
+                        <com.karrar.movieapp.ui.components.CustomSwitch
+                            android:id="@+id/dark_mode_switch"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            android:layout_marginEnd="16dp"
+                            />
+
                     </androidx.constraintlayout.widget.ConstraintLayout>
 
                     <com.google.android.material.divider.MaterialDivider

--- a/app/src/main/res/layout/switch_taggle.xml
+++ b/app/src/main/res/layout/switch_taggle.xml
@@ -2,18 +2,17 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="#1a1a1a">
+    android:layout_height="match_parent">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/switch_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="100dp"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        >
 
+        <!-- on -->
         <FrameLayout
             android:id="@+id/switch_enabled_on"
             android:layout_width="40dp"
@@ -34,59 +33,21 @@
 
         </FrameLayout>
 
+        <!-- off -->
         <FrameLayout
             android:id="@+id/switch_enabled_off"
             android:layout_width="40dp"
             android:layout_height="24dp"
-            android:layout_marginStart="24dp"
             android:background="@drawable/switch_track_off"
             android:clickable="true"
             android:focusable="true"
-            app:layout_constraintStart_toEndOf="@id/switch_enabled_on"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:visibility="gone"
+            >
 
             <View
                 android:id="@+id/thumb_enabled_off"
-                android:layout_width="20dp"
-                android:layout_height="20dp"
-                android:layout_gravity="start|center_vertical"
-                android:layout_marginStart="2dp"
-                android:background="@drawable/switch_thumb_gray" />
-
-        </FrameLayout>
-
-        <FrameLayout
-            android:id="@+id/switch_disabled_on"
-            android:layout_width="40dp"
-            android:layout_height="24dp"
-            android:layout_marginTop="24dp"
-            android:alpha="0.5"
-            android:background="@drawable/switch_track_off"
-            app:layout_constraintStart_toStartOf="@id/switch_enabled_on"
-            app:layout_constraintTop_toBottomOf="@id/switch_enabled_on">
-
-            <View
-                android:id="@+id/thumb_disabled_on"
-                android:layout_width="20dp"
-                android:layout_height="20dp"
-                android:layout_gravity="end|center_vertical"
-                android:layout_marginEnd="2dp"
-                android:background="@drawable/switch_thumb_gray" />
-
-        </FrameLayout>
-
-        <FrameLayout
-            android:id="@+id/switch_disabled_off"
-            android:layout_width="40dp"
-            android:layout_height="24dp"
-            android:layout_marginTop="24dp"
-            android:alpha="0.5"
-            android:background="@drawable/switch_track_off"
-            app:layout_constraintStart_toStartOf="@id/switch_enabled_off"
-            app:layout_constraintTop_toBottomOf="@id/switch_enabled_off">
-
-            <View
-                android:id="@+id/thumb_disabled_off"
                 android:layout_width="20dp"
                 android:layout_height="20dp"
                 android:layout_gravity="start|center_vertical"

--- a/app/src/main/res/layout/switch_toggle.xml
+++ b/app/src/main/res/layout/switch_toggle.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/switch_container"
@@ -58,4 +56,4 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</merge>

--- a/app/src/main/res/layout/switch_toggle.xml
+++ b/app/src/main/res/layout/switch_toggle.xml
@@ -6,8 +6,6 @@
         android:id="@+id/switch_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
         >
 
         <!-- on -->
@@ -16,8 +14,6 @@
             android:layout_width="40dp"
             android:layout_height="24dp"
             android:background="@drawable/switch_track_on"
-            android:clickable="true"
-            android:focusable="true"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
@@ -37,8 +33,6 @@
             android:layout_width="40dp"
             android:layout_height="24dp"
             android:background="@drawable/switch_track_off"
-            android:clickable="true"
-            android:focusable="true"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             android:visibility="gone"

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,18 @@
+# Versioning follows Semantic Versioning: MAJOR.MINOR.PATCH
+#
+# MAJOR: Increment when you make incompatible changes (breaking changes).
+#        Example: redesign core features, remove or change APIs, database structure changes.
+#
+# MINOR: Increment when you add functionality in a backward-compatible manner.
+#        Example: add a new feature, add a new screen, performance improvements.
+#
+# PATCH: Increment when you make backward-compatible bug fixes.
+#        Example: fix crashes, small UI bugs, minor logic issues.
+#
+# Examples:
+# 1.0.0 -> 1.0.1 (bug fix)
+# 1.0.0 -> 1.1.0 (new feature)
+# 1.0.0 -> 2.0.0 (breaking change)
 MAJOR=1
 MINOR=0
-PATCH=1
+PATCH=3


### PR DESCRIPTION
This PR adds a dark mode theme toggle functionality to the profile screen using a custom switch component. The implementation allows users to manually switch between light and dark themes with preference persistence.

- Implements a custom switch component for theme toggling
-Adds dark mode toggle functionality to the profile fragment
- Persists theme preferences using SharedPreferences and applies them on app startup


https://github.com/user-attachments/assets/9cbb4c7a-8aae-4bc4-aa21-b0be002d0d79
